### PR TITLE
fixes the crash while building the APK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,11 +27,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-    //buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,8 +26,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 28
+    //buildToolsVersion '25.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/ios/contact_picker.podspec
+++ b/ios/contact_picker.podspec
@@ -16,6 +16,6 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
 end
 

--- a/ios/contact_picker.podspec
+++ b/ios/contact_picker.podspec
@@ -16,6 +16,6 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
Resources of `25` compile SDK does not match with `28`

```
FAILURE: Build failed with an exception.                                
                                                                        
* What went wrong:                                                      
Execution failed for task ':contact_picker:verifyReleaseResources'.     
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > Android resource linking failed                                    
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontStyle not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/font not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontWeight not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/fontVariationSettings not found.
                                                                        
     /home/harsh/.gradle/caches/transforms-2/files-2.1/79a43a903ecb6dc82204ee669e724ddc/core-1.0.0/res/values/values.xml:57:5-88:25: AAPT: error: resource android:attr/ttcIndex not found.
```